### PR TITLE
Updated to the new name in a few places

### DIFF
--- a/Assets/API/Editor/GensoEditor.cs
+++ b/Assets/API/Editor/GensoEditor.cs
@@ -23,14 +23,14 @@ namespace Genso.API.Editor {
             CreateAsset<CharacterData>();
         }
 
-        [MenuItem("Genso/Clear Player Prefs %#c")]
+        [MenuItem("Crescendo/Clear Player Prefs %#c")]
         public static void ClearPlayerPrefs()
         {
             PlayerPrefs.DeleteAll();
             Debug.Log("Player Prefs Cleared.");
         }
 
-        [MenuItem("Genso/Build Windows", false, 51)]
+        [MenuItem("Crescendo/Build Windows", false, 51)]
         public static void BuildWindows()
         {
             string buildFolder = buildRoot + "Windows/";
@@ -39,20 +39,20 @@ namespace Genso.API.Editor {
             Build(buildFolder, BuildTarget.StandaloneWindows64);
         }
 
-        [MenuItem("Genso/Build Mac", false, 51)]
+        [MenuItem("Crescendo/Build Mac", false, 51)]
         public static void BuildMac()
         {
             string buildFolder = buildRoot + "Mac/";
             Build(buildFolder, BuildTarget.StandaloneOSXUniversal);
         }
 
-        [MenuItem("Genso/Build Linux", false, 51)]
+        [MenuItem("Crescendo/Build Linux", false, 51)]
         public static void BuildLinux() {
             string buildFolder = buildRoot + "Linux/";
             Build(buildFolder, BuildTarget.StandaloneLinuxUniversal);
         }
 
-        [MenuItem("Genso/Build All", false, 101)]
+        [MenuItem("Crescendo/Build All", false, 101)]
         public static void BuildAll() {
             BuildWindows();
             BuildMac();
@@ -112,7 +112,7 @@ namespace Genso.API.Editor {
             foreach(DirectoryInfo subdirectory in directory.GetDirectories())
                 subdirectory.Delete(true);
 
-            string executablePath = path + "genso";
+            string executablePath = path + "fantasycrescendo";
             switch (target) {
                 case BuildTarget.StandaloneWindows:
                 case BuildTarget.StandaloneWindows64:

--- a/Assets/Editor/Genso Color PResets.colors
+++ b/Assets/Editor/Genso Color PResets.colors
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12323, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: Genso Color PResets
+  m_Name: Crescendo Color PResets
   m_EditorClassIdentifier: 
   m_Presets:
   - m_Name: 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing to GensoShojokosen
+## Contributing to FantasyCrescendo
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your
 help is essential for keeping it great.
@@ -36,5 +36,5 @@ them as separate pull requests.
 - [Using Pull Requests](https://help.github.com/articles/using-pull-requests/)
 - [GitHub Help](https://help.github.com)
 
-[fork]: https://github.com/HouraiTeahouse/GensoShojokosen/fork
-[pr]: https://github.com/HouraiTeahouse/GensoShojokosen/compare
+[fork]: https://github.com/HouraiTeahouse/FantasyCrescendo/fork
+[pr]: https://github.com/HouraiTeahouse/FantasyCrescendo/compare

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This part is about to setting up a development enviroment for contributing to th
 ## Release Installation
 This part is about setting up and running released precompiled binaries.
 
-0. Visit the [Releases](https://github.com/HouraiTeahouse/GensoShojokosen/releases) page on this repository for the latest releases.
+0. Visit the [Releases](https://github.com/HouraiTeahouse/FantasyCrescendo/releases) page on this repository for the latest releases.
 0. On each release will be attached three ZIPs. One for Windows, one for Mac, one for Linux (Debian based distros only).
 0. Download and unzip the ZIPs.
 0. Run the main executable in the root directory of the extracted folder.
@@ -29,9 +29,9 @@ This part is about setting up and running released precompiled binaries.
 This is an open project, intended to be a community driven project. Contributions are very welcome. Code/software based contributions can be received and reviewed publicly on this repository. Non-code assets like BGM or 3D models are best sent to the project's open mailbox: simply mail teahouse.hourai@gmail.com. For more information, please read [this](./CONTRIBUTING.md).
 
 ## Licensing
-First and foremost, Gensō Shōjokōsen is a derivative of Touhou project. Thus, we ask that any redistirbution or derivative of this project adhere to the guidelines created by ZUN, [viewable in English here](http://en.touhouwiki.net/wiki/Touhou_Wiki:Copyrights). 
+First and foremost, *Fantasy Crescendo ~ Rumble Dream Ensemble* is a derivative of Touhou project. Thus, we ask that any redistirbution or derivative of this project adhere to the guidelines created by ZUN, [viewable in English here](http://en.touhouwiki.net/wiki/Touhou_Wiki:Copyrights). 
 
-Furthermore, Gensō Shōjokōsen is licensed under two seperate liscenses depending what content is in question:  
+Furthermore, *Fantasy Crescendo ~ Rumble Dream Ensemble* is licensed under two seperate liscenses depending what content is in question:  
 - The software (the written code) itself is under the GNU Public License Version v3.0. See [here](./SOFTWARE_LICENSE) for more information.
 - The content, virtually everything else, is under a CC BY-NC-SA v4.0 license. See [here!](./CONTENT_LICENSE) for more information.
 


### PR DESCRIPTION
I personally don't like the new name, but if you're going to change it, you REALLY don't want to go halfway.
- Updated README.md and CONTRIBUTING.md, which both still called it "GensoShojokosen" in a few places
- Renamed the Genso menu items to Crescendo
- Changed the name of the built executable
- Renamed the default color pallette to Crescendo as well
Genso.API should be renamed to Crescendo.API as well, but I didn't want to touch code you might be working on.