### PR TITLE
Lock Movement During Attack

### DIFF
--- a/Assets/API/Character/Components/CharacterAnimator.cs
+++ b/Assets/API/Character/Components/CharacterAnimator.cs
@@ -77,22 +77,24 @@ namespace Crescendo.API {
         }
 
         protected override void OnUpdate() {
-            _helpless.Set(Character.IsHelpless);
+			_helpless.Set (Character.IsHelpless);
 
-            Vector2 velocity = Character.Velocity;
-            _horizontalSpeed.Set(Mathf.Abs(velocity.x));
-            _verticalSpeed.Set(velocity.y);
+			Vector2 velocity = Character.Velocity;
+			_horizontalSpeed.Set (Mathf.Abs (velocity.x));
+			_verticalSpeed.Set (velocity.y);
 
-            if (InputSource == null)
-                return;
+			if (InputSource == null)
+				return;
 
-            Vector2 movementInput = InputSource.Movement;
-            _horizontalInput.Set(Mathf.Abs(movementInput.x));
-            _verticalInput.Set(movementInput.y);
+			Vector2 movementInput = InputSource.Movement;
+			_horizontalInput.Set (Mathf.Abs (movementInput.x));
+			_verticalInput.Set (movementInput.y);
         }
 
         void OnAttack() {
             _attack.Set();
+			// Lock movement for the duration of the attack animation
+			StartCoroutine(Character.LockMovement(_animator.GetCurrentAnimatorStateInfo(0).length));
         }
 
         void OnJump() {

--- a/Assets/Static/Characters/Marisa/marisa_controller.controller
+++ b/Assets/Static/Characters/Marisa/marisa_controller.controller
@@ -20,6 +20,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
+  - m_Name: attack
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   - m_Name: jump
     m_Type: 9
     m_DefaultFloat: 0
@@ -27,12 +33,6 @@ AnimatorController:
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
   - m_Name: air jump
-    m_Type: 9
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 0}
-  - m_Name: attack
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
@@ -74,7 +74,7 @@ AnimatorController:
     m_DefaultWeight: 0
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
 --- !u!1101 &110101010
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -100,7 +100,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -130,7 +130,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -175,7 +175,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -208,7 +208,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -300,7 +300,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_Motion: {fileID: 7400000, guid: f7bf785fd1012804f9a024dd5c4454ca, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: horizontal speed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
 --- !u!1102 &110228112
@@ -324,7 +324,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_Motion: {fileID: 7400000, guid: e9f5445d06b047a459809d84c7abdd37, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: horizontal speed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
 --- !u!1102 &110253234
@@ -351,7 +351,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 69d89899e3e7eba47a3ceadd175e91ff, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: horizontal speed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
 --- !u!1102 &110283378
@@ -375,7 +375,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 6ec66793c6a17474bb649df5fb70da1a, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: horizontal speed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
 --- !u!1102 &110284052
@@ -399,7 +399,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 21837d2bc1129d64b90fcc1b3bbb415e, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: horizontal speed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
 --- !u!1107 &110714198

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -27,7 +27,7 @@ PlayerSettings:
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
   iosAppInBackgroundBehavior: 0
-  displayResolutionDialog: 1
+  displayResolutionDialog: 0
   allowedAutorotateToPortrait: 1
   allowedAutorotateToPortraitUpsideDown: 1
   allowedAutorotateToLandscapeRight: 1


### PR DESCRIPTION
Players will now not be able to move or jump while they are attacking.
Added a LockMovement method and a _canMove state variable to help with
this.
The method is somewhat sloppily called, and it doesn't play well with
aerial characters, but otherwise it works as intended.
*Also unchecked "Has Exit Time" from all animation transitions coming
from idle, since this was causing an (assumedly) unintentional delay
where other animations wouldn't play until the idle animation was
finished.