### PR TITLE
Make fast-falling "sticky"

### DIFF
--- a/Assets/Scripts/Character/Components/Physics/CharacterFalling.cs
+++ b/Assets/Scripts/Character/Components/Physics/CharacterFalling.cs
@@ -13,8 +13,11 @@ namespace Genso.API {
         [SerializeField]
         private float _maxFallSpeed = 5f;
 
+        [SerializeField]
+        private bool _fastFallInputted = false;
+
         public bool IsFastFalling {
-            get { return Character != null && InputSource != null && !Character.IsGrounded && InputSource.Crouch; }
+            get { return Character != null && InputSource != null && !Character.IsGrounded && _fastFallInputted;}
         }
 
         public float FallSpeed {
@@ -23,6 +26,15 @@ namespace Genso.API {
 
         private void FixedUpdate() {
             Vector3 velocity = Character.Velocity;
+
+            
+            if (!IsFastFalling && InputSource != null && InputSource.Crouch){
+                _fastFallInputted = true;    
+            }
+            
+            if (Character.IsGrounded){
+                _fastFallInputted = false;
+            }
 
             if (IsFastFalling || velocity.y < -FallSpeed)
                 velocity.y = -FallSpeed;


### PR DESCRIPTION
In smash, you only need to press down once to fastfall; the logic you implemented will make the character stop fast-falling and go back to regular falling if you let go of down in midair. This fixes that!

I don't check to see if character != null during FixedUpdate(); but since it would throw an error anyways on the line before I'm going to say it's fine.

This is a code change, which I said I wouldn't do, though... can I claim this is a typo in your logic?  :)