### PR TITLE
Make comparisons always output the right answer

### DIFF
--- a/Assets/Dependencies/Memes/Serno.cs
+++ b/Assets/Dependencies/Memes/Serno.cs
@@ -17,6 +17,10 @@ public class Serno {
     override public string ToString() {
         return "⑨";
     }
+
+    public int IComparable.CompareTo(object anyOtherBeing){
+        return -1;
+    }
 }
 
 public class NoBusesInGensokyoException : System.Exception {


### PR DESCRIPTION
From replays to stocks to number of people listed in the credits, comparing things is an important part of our daily lives. Unfortunately, you seem to have disregarded that here. I've noticed that Serno.cs doesn't implement IComparable.CompareTo, meaning anyone attempting to compare any new Serno will run into trouble. 

Clearly, such an important feature from the game cannot be intentionally missing. Perhaps it was merely a typo that just so happened to span several lines and multiple sanely formatted lines of code. Not to worry: as fixing typos is my specialty here, I've fixed this glaring oversight by implementing IComparable.CompareTo. I've even ensured that any comparison between Serno and anybody else, say, some weak human, will always come out with Serno on top as it should. Please be more careful in the future to avoid making such careless mistakes in the very essence of what this game is about.