### PR TITLE
Added state machine to MatchState for restricting Simulations.

### DIFF
--- a/Assets/Code/src/Runtime/Core/GameController.cs
+++ b/Assets/Code/src/Runtime/Core/GameController.cs
@@ -10,27 +10,32 @@ public class MatchController : IMatchController {
 
   public virtual uint Timestep { get; set; }
   public virtual MatchState CurrentState { get; set; }
+  public virtual MatchProgressionState CurrentProgressionID {
+    get { return CurrentState.StateID; }
+    set { CurrentState.StateID = value; }
+  }
+
   public virtual ISimulation<MatchState, MatchInputContext> Simulation { get; set; }
   public virtual IMatchInputSource InputSource { get; set; }
 
   readonly MatchInputContext inputContext;
-
+  
   public MatchController(MatchConfig config) {
     inputContext = new MatchInputContext(new MatchInput(config));
   }
 
   public virtual void Update() {
-	 if (CurrentState.StateID != MatchStateID.Intro) {
-		var input = InputSource.SampleInput();
-		Assert.IsTrue(input.IsValid);
-		inputContext.Update(input);
-	 }
+    if (CurrentProgressionID != MatchProgressionState.Intro) {
+	   var input = InputSource.SampleInput();
+	   Assert.IsTrue(input.IsValid);
+	   inputContext.Update(input);
+    }
     
-	 var state = CurrentState;
-	 Simulation.Simulate(ref state, inputContext);
-	 CurrentState = state;
+    var state = CurrentState;
+    Simulation.Simulate(ref state, inputContext);
+    CurrentState = state;
 
-	 Timestep++;
+    Timestep++;
   }
 
 }

--- a/Assets/Code/src/Runtime/Core/GameController.cs
+++ b/Assets/Code/src/Runtime/Core/GameController.cs
@@ -10,11 +10,6 @@ public class MatchController : IMatchController {
 
   public virtual uint Timestep { get; set; }
   public virtual MatchState CurrentState { get; set; }
-  public virtual MatchProgressionState CurrentProgressionID {
-    get { return CurrentState.StateID; }
-    set { CurrentState.StateID = value; }
-  }
-
   public virtual ISimulation<MatchState, MatchInputContext> Simulation { get; set; }
   public virtual IMatchInputSource InputSource { get; set; }
 
@@ -25,7 +20,7 @@ public class MatchController : IMatchController {
   }
 
   public virtual void Update() {
-    if (CurrentProgressionID != MatchProgressionState.Intro) {
+    if (CurrentState.StateID != MatchProgressionState.Intro) {
 	   var input = InputSource.SampleInput();
 	   Assert.IsTrue(input.IsValid);
 	   inputContext.Update(input);

--- a/Assets/Code/src/Runtime/Core/GameController.cs
+++ b/Assets/Code/src/Runtime/Core/GameController.cs
@@ -19,19 +19,18 @@ public class MatchController : IMatchController {
     inputContext = new MatchInputContext(new MatchInput(config));
   }
 
-public virtual void Update() {
-    // BIG TODO: Find a better workaround instead of calling for MatchManager variables
-    if (MatchManager.Instance.IsControllerRunning){
-        var input = InputSource.SampleInput();
-        Assert.IsTrue(input.IsValid);
-        inputContext.Update(input);
-    }
+  public virtual void Update() {
+	 if (CurrentState.StateID != MatchStateID.Intro) {
+		var input = InputSource.SampleInput();
+		Assert.IsTrue(input.IsValid);
+		inputContext.Update(input);
+	 }
+    
+	 var state = CurrentState;
+	 Simulation.Simulate(ref state, inputContext);
+	 CurrentState = state;
 
-    var state = CurrentState;
-    Simulation.Simulate(ref state, inputContext);
-    CurrentState = state;
-
-    Timestep++;
+	 Timestep++;
   }
 
 }

--- a/Assets/Code/src/Runtime/Core/IGameController.cs
+++ b/Assets/Code/src/Runtime/Core/IGameController.cs
@@ -20,6 +20,11 @@ public interface IMatchController {
   MatchState CurrentState { get; set; }
 
   /// <summary>
+  /// Ease of use accessor for the match progress ID for the current game state.
+  /// </summary>
+  MatchProgressionState CurrentProgressionID { get; set; }
+
+  /// <summary>
   /// Update the game state. Expected to be called once per Unity FixedUpdate.
   /// </summary>
   void Update();

--- a/Assets/Code/src/Runtime/Core/IGameController.cs
+++ b/Assets/Code/src/Runtime/Core/IGameController.cs
@@ -20,11 +20,6 @@ public interface IMatchController {
   MatchState CurrentState { get; set; }
 
   /// <summary>
-  /// Ease of use accessor for the match progress ID for the current game state.
-  /// </summary>
-  MatchProgressionState CurrentProgressionID { get; set; }
-
-  /// <summary>
   /// Update the game state. Expected to be called once per Unity FixedUpdate.
   /// </summary>
   void Update();

--- a/Assets/Code/src/Runtime/Match/Components/MatchCountdownUI.cs
+++ b/Assets/Code/src/Runtime/Match/Components/MatchCountdownUI.cs
@@ -7,72 +7,80 @@ namespace HouraiTeahouse.FantasyCrescendo.Matches
 
 public class MatchCountdownUI : MonoBehaviour
 {
-    // Component References
-    [Header("Component References")]
-    public TextMeshProUGUI TextUI;
-    public AudioSource AudioPlayer;
+  // Component References
+  [Header("Component References")]
+  public TextMeshProUGUI TextUI;
+  public AudioSource AudioPlayer;
 
-    [Header("Timings")]
-    public float InitialDelay = 1f;
+  [Header("Timings")]
+  public float InitialDelay = 1f;
 
-    [Header("Countdown Clips (0 = 'GO', 1-3 = Time)")]
-    public AudioClip[] CountdownClips;
+  [Header("Countdown Clips (0 = 'GO', 1-3 = Time)")]
+  public AudioClip[] CountdownClips;
 
-    [Header("Debug")]
-    public bool DisableCountdown = false;
+  [Header("Debug")]
+  public bool DisableCountdown = false;
 
-    /// <summary>
-    /// Awake is called when the script instance is being loaded.
-    /// </summary>
-    void Awake() {
-        Mediator.Global.CreateUnityContext(this)
-            .Subscribe<MatchStartCountdownEvent>(StartCountdown);
-        TextUI = GetComponentInChildren<TextMeshProUGUI>();
-        AudioPlayer = GetComponentInChildren<AudioSource>();
+  /// <summary>
+  /// Awake is called when the script instance is being loaded.
+  /// </summary>
+  void Awake() {
+    Mediator.Global.CreateUnityContext(this)
+        .Subscribe<MatchStartCountdownEvent>(StartCountdown);
+    TextUI = GetComponentInChildren<TextMeshProUGUI>();
+    AudioPlayer = GetComponentInChildren<AudioSource>();
+  }
+
+  /// <summary>
+  /// Starts countdown UI. Based on Stage GUI's CountdownClips array.
+  /// Each Countdown Audio Clip's length influences how long the text is displayed
+  /// Returns when GO! is reached, but GO! will continue to be displayed for its duration
+  /// </summary>
+  /// <param name="evt"></param>
+  /// <returns></returns>
+  async Task StartCountdown(MatchStartCountdownEvent evt) {
+    // For Debug purposes and you don't want to wait
+    if (DisableCountdown && Debug.isDebugBuild) return;
+
+    await Task.Delay((int)(InitialDelay * 1000));
+    ObjectUtil.SetActive(TextUI.gameObject, true);
+
+    var timer = CountdownClips.Length - 1;
+    while (timer > 0) {
+      await UpdateTextUI(timer.ToString(), CountdownClips[timer]);
+      timer--;
     }
+    // TODO: Make GO! string into localization string 
+    UpdateTextUIGO("GO!", CountdownClips[0]);
+  }
 
-    /// <summary>
-    /// Starts countdown UI. Based on Stage GUI's CountdownClips array.
-    /// Each Countdown Audio Clip's length influences how long the text is displayed
-    /// Returns when GO! is reached, but GO! will continue to be displayed for its duration
-    /// </summary>
-    /// <param name="evt"></param>
-    /// <returns></returns>
-    async Task StartCountdown(MatchStartCountdownEvent evt) {
-        // For Debug purposes and you don't want to wait
-        if (DisableCountdown && Debug.isDebugBuild) return;
+  /// <summary>
+  /// Updates Text GUI text based on input and plays AudioClip.
+  /// Used for countdown for the await
+  /// </summary>
+  /// <param name="text"></param>
+  /// <param name="audio"></param>
+  /// <returns></returns>
+  async Task UpdateTextUI(string text, AudioClip audio) {
+    TextUI.text = text;
+    AudioPlayer.clip = audio;
+    AudioPlayer.Play();
 
-        await Task.Delay((int)(InitialDelay * 1000));
-        ObjectUtil.SetActive(TextUI.gameObject, true);
+    await Task.Delay((int)(audio.length * 1000));
+  }
 
-        var timer = CountdownClips.Length - 1;
-        while (timer > 0) {
-            await UpdateTextUI(timer.ToString(), CountdownClips[timer]);
-            timer--;
-        }
-        // TODO: Make GO! string into localization string 
-        UpdateTextUI("GO!", CountdownClips[0], true);
-    }
+  /// <summary>
+  /// Updates Text GUI text based on input and plays AudioClip.
+  /// Used for go to remove the warning.
+  /// </summary>
+  /// <param name="text"></param>
+  /// <param name="audio"></param>
+  async void UpdateTextUIGO(string text, AudioClip audio){
+    await UpdateTextUI(text, audio);
+    ObjectUtil.SetActive(TextUI.gameObject, false);
+  }
 
-    /// <summary>
-    /// Updates Text GUI text based on input and plays AudioClip.
-    /// Controls display time and whether it disappears afterwards as well
-    /// </summary>
-    /// <param name="_text"></param>
-    /// <param name="timer"></param>
-    /// <param name="autoDisappear"></param>
-    /// <returns></returns>
-    async Task UpdateTextUI(string text, AudioClip audio, bool autoDisappear=false) {
-        // Update Text and play Audio
-        TextUI.text = text;
-        AudioPlayer.clip = audio;
-        AudioPlayer.Play();
-
-        // Wait and maybe disable UI afterwards
-        await Task.Delay((int)(audio.length * 1000));
-        if (autoDisappear)
-            ObjectUtil.SetActive(TextUI.gameObject, false);
-    }
+    
 }
 
 }

--- a/Assets/Code/src/Runtime/Match/Components/MatchManager.cs
+++ b/Assets/Code/src/Runtime/Match/Components/MatchManager.cs
@@ -14,6 +14,15 @@ public class MatchManager : MonoBehaviour {
 
   public bool IsLocal => Config.IsLocal;
 
+  public MatchProgressionState CurrentProgressionID {
+    get{
+      return MatchController.CurrentState.StateID;
+    }
+    set{
+      MatchController.CurrentState.StateID = value;
+    }
+  }
+
   TaskCompletionSource<MatchResult> MatchTask;
 
   /// <summary>
@@ -28,7 +37,7 @@ public class MatchManager : MonoBehaviour {
   /// This function is called every fixed framerate frame, if the MonoBehaviour is enabled.
   /// </summary>
   void FixedUpdate() {
-    if (MatchController?.CurrentProgressionID != MatchProgressionState.Pause) {
+    if (MatchController != null && CurrentProgressionID != MatchProgressionState.Pause) {
       MatchController.Update();
     }
 
@@ -49,7 +58,7 @@ public class MatchManager : MonoBehaviour {
     }
 
     Debug.Log("Starting cooldown...");
-    MatchController.CurrentProgressionID = MatchProgressionState.Intro;
+    CurrentProgressionID = MatchProgressionState.Intro;
     await Mediator.Global.PublishAsync(new MatchStartCountdownEvent
     {
         MatchConfig = Config,
@@ -57,7 +66,7 @@ public class MatchManager : MonoBehaviour {
     });
 		
 	 Debug.Log("Running match...");
-	 MatchController.CurrentProgressionID = MatchProgressionState.InGame;
+    CurrentProgressionID = MatchProgressionState.InGame;
 	 MatchTask = new TaskCompletionSource<MatchResult>();
     Mediator.Global.Publish(new MatchStartEvent {
       MatchConfig = Config,
@@ -70,16 +79,16 @@ public class MatchManager : MonoBehaviour {
       MatchConfig = Config,
       MatchState = MatchController.CurrentState
     });
-	 MatchController.CurrentProgressionID = MatchProgressionState.End;
+    CurrentProgressionID = MatchProgressionState.End;
 	 return result;
   }
 
   public void SetPaused(bool paused) {
     if (!IsLocal) return;
 
-	 var pauseID = paused ? MatchProgressionState.Pause : MatchProgressionState.InGame;
-	 bool changed = pauseID != MatchController.CurrentProgressionID;
-	 MatchController.CurrentProgressionID = pauseID;
+    var pauseID = paused ? MatchProgressionState.Pause : MatchProgressionState.InGame;
+    bool changed = pauseID != CurrentProgressionID;
+    CurrentProgressionID = pauseID;
     if (changed) {
       Mediator.Global.Publish(new MatchPauseStateChangedEvent {
         MatchConfig = Config,

--- a/Assets/Code/src/Runtime/Match/Components/MatchManager.cs
+++ b/Assets/Code/src/Runtime/Match/Components/MatchManager.cs
@@ -28,8 +28,9 @@ public class MatchManager : MonoBehaviour {
   /// This function is called every fixed framerate frame, if the MonoBehaviour is enabled.
   /// </summary>
   void FixedUpdate() {
-    if (MatchController.CurrentState.StateID != MatchStateID.Pause)
-      MatchController?.Update();
+    if (MatchController?.CurrentProgressionID != MatchProgressionState.Pause) {
+      MatchController.Update();
+    }
 
   }
 
@@ -48,15 +49,15 @@ public class MatchManager : MonoBehaviour {
     }
 
     Debug.Log("Starting cooldown...");
-	 MatchController.CurrentState.StateID = MatchStateID.Intro;
-	 await Mediator.Global.PublishAsync(new MatchStartCountdownEvent
+    MatchController.CurrentProgressionID = MatchProgressionState.Intro;
+    await Mediator.Global.PublishAsync(new MatchStartCountdownEvent
     {
         MatchConfig = Config,
         MatchState = MatchController.CurrentState
     });
 		
 	 Debug.Log("Running match...");
-	 MatchController.CurrentState.StateID = MatchStateID.InGame;
+	 MatchController.CurrentProgressionID = MatchProgressionState.InGame;
 	 MatchTask = new TaskCompletionSource<MatchResult>();
     Mediator.Global.Publish(new MatchStartEvent {
       MatchConfig = Config,
@@ -69,16 +70,16 @@ public class MatchManager : MonoBehaviour {
       MatchConfig = Config,
       MatchState = MatchController.CurrentState
     });
-	 MatchController.CurrentState.StateID = MatchStateID.End;
+	 MatchController.CurrentProgressionID = MatchProgressionState.End;
 	 return result;
   }
 
   public void SetPaused(bool paused) {
     if (!IsLocal) return;
 
-	 var pauseID = paused ? MatchStateID.Pause : MatchStateID.InGame;
-	 bool changed = pauseID != MatchController.CurrentState.StateID;
-	 MatchController.CurrentState.StateID = pauseID;
+	 var pauseID = paused ? MatchProgressionState.Pause : MatchProgressionState.InGame;
+	 bool changed = pauseID != MatchController.CurrentProgressionID;
+	 MatchController.CurrentProgressionID = pauseID;
     if (changed) {
       Mediator.Global.Publish(new MatchPauseStateChangedEvent {
         MatchConfig = Config,

--- a/Assets/Code/src/Runtime/Match/Components/MatchPauseController.cs
+++ b/Assets/Code/src/Runtime/Match/Components/MatchPauseController.cs
@@ -25,9 +25,9 @@ public class MatchPauseController : MonoBehaviour {
   /// </summary>
   void Update() {
     if (MatchManager == null || !MatchManager.IsLocal) return;
-    if (MatchManager.MatchController.CurrentProgressionID == MatchProgressionState.Pause) {
+    if (MatchManager.CurrentProgressionID == MatchProgressionState.Pause) {
       PausedCheck();
-    } else if (MatchManager.MatchController.CurrentProgressionID == MatchProgressionState.InGame) {
+    } else if (MatchManager.CurrentProgressionID == MatchProgressionState.InGame) {
       UnpausedCheck();
     }
   }

--- a/Assets/Code/src/Runtime/Match/Components/MatchPauseController.cs
+++ b/Assets/Code/src/Runtime/Match/Components/MatchPauseController.cs
@@ -25,9 +25,9 @@ public class MatchPauseController : MonoBehaviour {
   /// </summary>
   void Update() {
     if (MatchManager == null || !MatchManager.IsLocal) return;
-    if (MatchManager.IsPaused) {
+    if (MatchManager.MatchController.CurrentState.StateID == MatchStateID.Pause) {
       PausedCheck();
-    } else {
+    } else if (MatchManager.MatchController.CurrentState.StateID == MatchStateID.InGame) {
       UnpausedCheck();
     }
   }

--- a/Assets/Code/src/Runtime/Match/Components/MatchPauseController.cs
+++ b/Assets/Code/src/Runtime/Match/Components/MatchPauseController.cs
@@ -6,7 +6,7 @@ namespace HouraiTeahouse.FantasyCrescendo {
 
 public class MatchPauseController : MonoBehaviour {
 
-  public MatchManager MatchManager;
+  public MatchManager MatchManager { get { return MatchManager.Instance; } }
   public KeyCode PlayerOneKey = KeyCode.Return;
   public InputControlType PauseButton = InputControlType.Start;
 
@@ -25,9 +25,9 @@ public class MatchPauseController : MonoBehaviour {
   /// </summary>
   void Update() {
     if (MatchManager == null || !MatchManager.IsLocal) return;
-    if (MatchManager.MatchController.CurrentState.StateID == MatchStateID.Pause) {
+    if (MatchManager.MatchController.CurrentProgressionID == MatchProgressionState.Pause) {
       PausedCheck();
-    } else if (MatchManager.MatchController.CurrentState.StateID == MatchStateID.InGame) {
+    } else if (MatchManager.MatchController.CurrentProgressionID == MatchProgressionState.InGame) {
       UnpausedCheck();
     }
   }

--- a/Assets/Code/src/Runtime/Match/MatchSimulation.cs
+++ b/Assets/Code/src/Runtime/Match/MatchSimulation.cs
@@ -23,14 +23,19 @@ public class MatchSimulation : IMatchSimulation {
   }
 
   public void Simulate(ref MatchState state, MatchInputContext input) {
-    SimulationComponents.Simulate(ref state, input);
+	 if(state.StateID == MatchStateID.InGame)
+		SimulationComponents.Simulate(ref state, input);
+	 else if (state.StateID == MatchStateID.Intro)
+		SimulateRestrict(ref state, input, typeof(MatchPlayerSimulation));
+	 else if (state.StateID == MatchStateID.End)
+		SimulateRestrict(ref state, input, typeof(MatchPlayerSimulation), typeof(MatchHitboxSimulation));
   }
 
   public MatchState ResetState(MatchState state) {
-    foreach (var component in SimulationComponents) {
-      state = component.ResetState(state);
-    }
-    return state;
+	 foreach (var component in SimulationComponents) {
+		state = component.ResetState(state);
+	 }
+	 return state;
   }
 
   public void Dispose() {
@@ -39,6 +44,14 @@ public class MatchSimulation : IMatchSimulation {
     }
   }
 
-}
+  void SimulateRestrict(ref MatchState state, MatchInputContext input, params Type[] restrictions) {
+	 foreach (var SimComponent in SimulationComponents) {
+		if (restrictions.Contains(SimComponent.GetType()))
+		  SimComponent.Simulate(ref state, input);
+  }
+  
+  }
+
+  }
     
 }

--- a/Assets/Code/src/Runtime/Match/MatchState.cs
+++ b/Assets/Code/src/Runtime/Match/MatchState.cs
@@ -7,6 +7,8 @@ using UnityEngine;
 
 namespace HouraiTeahouse.FantasyCrescendo.Matches {
 
+public enum MatchStateID { Intro, InGame, Pause, End }
+
 /// <summary>
 /// A complete representation of a given game's state at a given tick.
 /// </summary>
@@ -17,6 +19,7 @@ public class MatchState : INetworkSerializable {
 
   PlayerState[] playerStates;
   public int PlayerCount { get; private set; }
+  public MatchStateID StateID { get; set; } = MatchStateID.Intro;
 
   public MatchState() : this((int)GameMode.GlobalMaxPlayers) { }
 

--- a/Assets/Code/src/Runtime/Match/MatchState.cs
+++ b/Assets/Code/src/Runtime/Match/MatchState.cs
@@ -7,7 +7,27 @@ using UnityEngine;
 
 namespace HouraiTeahouse.FantasyCrescendo.Matches {
 
-public enum MatchStateID { Intro, InGame, Pause, End }
+  /// <summary>
+  /// Represents the match's state in game
+  /// </summary>
+public enum MatchProgressionState { 
+  /// <summary>
+  /// Before the game begins. Represents the countdown sequence.
+  /// </summary>
+  Intro, 
+  /// <summary>
+  /// Represents the game in progress.
+  /// </summary>
+  InGame, 
+  /// <summary>
+  /// Represents the game while paused. Can only be paused during InGame.
+  /// </summary>
+  Pause, 
+  /// <summary>
+  /// After the game results are in. Represents the GAME/TIME sequence.
+  /// </summary>
+  End 
+}
 
 /// <summary>
 /// A complete representation of a given game's state at a given tick.
@@ -19,7 +39,7 @@ public class MatchState : INetworkSerializable {
 
   PlayerState[] playerStates;
   public int PlayerCount { get; private set; }
-  public MatchStateID StateID { get; set; } = MatchStateID.Intro;
+  public MatchProgressionState StateID = MatchProgressionState.Intro;
 
   public MatchState() : this((int)GameMode.GlobalMaxPlayers) { }
 
@@ -75,6 +95,7 @@ public class MatchState : INetworkSerializable {
         playerStates[i].Serialize(writer);
       }
     }
+    writer.Write((byte)StateID);
   }
 
   public void Deserialize(Deserializer deserializer) {
@@ -88,6 +109,7 @@ public class MatchState : INetworkSerializable {
       }
       SetPlayerState(i, state);
     }
+    StateID = (MatchProgressionState)deserializer.ReadByte();
   }
 
   // TODO(james7132): Change to ref indexer when C# 7 is available.

--- a/Assets/Code/src/Runtime/Networking/Strategies/NetworkHostController.cs
+++ b/Assets/Code/src/Runtime/Networking/Strategies/NetworkHostController.cs
@@ -12,11 +12,19 @@ public sealed class NetworkHostController : IMatchController {
     }
   }
 
-  public MatchState CurrentState  {
+  public MatchState CurrentState {
     get { return ClientController.CurrentState; }
     set {
       ClientController.CurrentState = value;
       ServerController.CurrentState = value;
+    }
+  }
+
+  public MatchProgressionState CurrentProgressionID {
+    get { return ClientController.CurrentProgressionID; }
+    set {
+      ClientController.CurrentProgressionID = value;
+      ServerController.CurrentProgressionID = value;
     }
   }
 

--- a/Assets/Code/src/Runtime/Networking/Strategies/NetworkHostController.cs
+++ b/Assets/Code/src/Runtime/Networking/Strategies/NetworkHostController.cs
@@ -20,14 +20,6 @@ public sealed class NetworkHostController : IMatchController {
     }
   }
 
-  public MatchProgressionState CurrentProgressionID {
-    get { return ClientController.CurrentProgressionID; }
-    set {
-      ClientController.CurrentProgressionID = value;
-      ServerController.CurrentProgressionID = value;
-    }
-  }
-
   public ISimulation<MatchState, MatchInputContext> Simulation {
     get { return ClientController.Simulation; }
     set {


### PR DESCRIPTION
### Motivation and Context
- [X] Why is this change required? What problem does it solve?
Timer was playing during countdown and game results could theoretically change after the EndEvent but before stage switch. Furthermore, MatchManager was getting too many variables to represent the match's state. This fix addresses it by having "basically global" MatchStateID that represents the current state which can accessed by any script.
- [ ] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
Timer doesn't decrease during countdown.
- [X] Breaking change (fix or feature that would cause existing functionality to change)
MatchState now contains a StateID which represents the Match's, well, current state. Accessible.
What simulations called in MatchSimulation can be altered based on the MatchStateID.

### Description
- [X] Describe your changes in detail.
The commits and change list kinda explain it all. I'm not a too big of my implementation. Seems a little unclean.